### PR TITLE
fix(linter): Install fixed version of esquery v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vite": "4.1.1"
   },
   "overrides": {
-    "esquery": "1.4.0"
+    "esquery": "1.4.2"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
esquery package is a transitive dependency for us - and a broken version was released last night.

This commit fixes esquery to 1.4.2 since 1.4.1 is buggy

See: estools/esquery#135
Patched by: estools/esquery#138